### PR TITLE
Change background colour and add markdown support

### DIFF
--- a/ckanext/status/lib/helpers.py
+++ b/ckanext/status/lib/helpers.py
@@ -5,6 +5,11 @@
 # Created by the Natural History Museum in London, UK
 
 from ckan.plugins import toolkit
+import markdown
+
+
+def status_enable_html():
+    return toolkit.asbool(toolkit.config.get('ckanext.status.enable_html', True))
 
 
 def status_get_message():
@@ -15,4 +20,7 @@ def status_get_message():
     :rtype: string
     """
 
-    return toolkit.config.get('ckanext.status.message', None)
+    status_message = toolkit.config.get('ckanext.status.message', None)
+    if status_message and status_enable_html():
+        status_message = markdown.markdown(status_message)
+    return status_message

--- a/ckanext/status/plugin.py
+++ b/ckanext/status/plugin.py
@@ -5,7 +5,7 @@
 # Created by the Natural History Museum in London, UK
 
 from ckan.plugins import SingletonPlugin, implements, interfaces, toolkit
-from ckanext.status.lib.helpers import status_get_message
+from ckanext.status.lib.helpers import status_get_message, status_enable_html
 
 
 class StatusPlugin(SingletonPlugin):
@@ -33,4 +33,7 @@ class StatusPlugin(SingletonPlugin):
 
     # ITemplateHelpers
     def get_helpers(self):
-        return {'status_get_message': status_get_message}
+        return {
+            'status_get_message': status_get_message,
+            'status_enable_html': status_enable_html,
+        }

--- a/ckanext/status/theme/assets/less/status.less
+++ b/ckanext/status/theme/assets/less/status.less
@@ -5,4 +5,13 @@
   margin: 0;
   font-size: 1.3em;
   padding: 5px 0 10px;
+
+  & p {
+    margin: 0;
+  }
+
+  & a {
+    color: var(--ckanext-status-bar-fg, #ffffff);
+    text-decoration: underline;
+  }
 }

--- a/ckanext/status/theme/assets/less/status.less
+++ b/ckanext/status/theme/assets/less/status.less
@@ -1,7 +1,7 @@
 #status-bar {
   text-align: center;
-  background-color: #195d0d;
-  color: #ffffff;
+  background-color: var(--ckanext-status-bar-bg, #772e8a);
+  color: var(--ckanext-status-bar-fg, #ffffff);
   margin: 0;
   font-size: 1.3em;
   padding: 5px 0 10px;

--- a/ckanext/status/theme/templates/page.html
+++ b/ckanext/status/theme/templates/page.html
@@ -3,7 +3,13 @@
 {% block skip %}
     {% if h.status_get_message() %}
         {% asset 'ckanext-status/main' %}
-        <p id="status-bar">{{ h.status_get_message() }}</p>
+        <div id="status-bar">
+            {% if h.status_enable_html() %}
+                {{ h.status_get_message()|safe }}
+            {% else %}
+                {{ h.status_get_message() }}
+            {% endif %}
+        </div>
     {% endif %}
     {{ super() }}
 {% endblock %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ classifiers = [
     "Programming Language :: Python :: 3.8"
 ]
 dependencies = [
-    "ckantools>=0.3.0"
+    "ckantools>=0.3.0",
+    "markdown~=3.4"
 ]
 
 [project.optional-dependencies]

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -6,17 +6,31 @@
 import pytest
 from ckan.plugins import toolkit
 from ckanext.status.lib.helpers import status_get_message
+import markdown
 
 TEST_MESSAGE = 'this is a test message'
+MARKDOWN_TEST_MESSAGE = '_this_ is a test **message**'
+HTML_TEST_MESSAGE = '<p><em>this</em> is a test <strong>message</strong></p>'
 
 
 @pytest.mark.filterwarnings('ignore::sqlalchemy.exc.SADeprecationWarning')
 @pytest.mark.ckan_config('ckan.plugins', 'status')
 @pytest.mark.ckan_config('ckanext.status.message', TEST_MESSAGE)
+@pytest.mark.ckan_config('ckanext.status.enable_html', False)
 @pytest.mark.usefixtures('with_plugins')
 def test_helper_gets_message_when_present():
     message = status_get_message()
     assert message == TEST_MESSAGE
+
+
+@pytest.mark.filterwarnings('ignore::sqlalchemy.exc.SADeprecationWarning')
+@pytest.mark.ckan_config('ckan.plugins', 'status')
+@pytest.mark.ckan_config('ckanext.status.message', MARKDOWN_TEST_MESSAGE)
+@pytest.mark.ckan_config('ckanext.status.enable_html', True)
+@pytest.mark.usefixtures('with_plugins')
+def test_helper_parses_markdown_message():
+    message = status_get_message()
+    assert message == HTML_TEST_MESSAGE
 
 
 @pytest.mark.filterwarnings('ignore::sqlalchemy.exc.SADeprecationWarning')


### PR DESCRIPTION
- background and foreground colours set by css vars (`--ckanext-status-bar-bg` and `--ckanext-status-bar-fg`)
- changed default background to purple
- added support for markdown in the status message
- added config option to turn off markdown parsing/html rendering if necessary (`ckanext.status.enable_html`); on by default

Closes #20 