### PR TITLE
Update docker command for test runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build images
-        run: docker-compose build
+        run: docker compose build
 
       - name: Run tests
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: docker-compose run -e COVERALLS_REPO_TOKEN ckan bash /opt/scripts/run-tests.sh -c ckanext.status
+        run: docker compose run -e COVERALLS_REPO_TOKEN ckan bash /opt/scripts/run-tests.sh -c ckanext.status

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ Installing from a `pyproject.toml` in editable mode (i.e. `pip install -e`) requ
 # Usage
 
 <!--usage-start-->
-
 ## Status bar
 
 To turn the status bar on, login as a sysadmin and head to the system configuration page.
@@ -133,7 +132,7 @@ To run the tests against ckan 2.9.x on Python3:
 
 1. Build the required images:
    ```shell
-   docker-compose build
+   docker compose build
    ```
 
 2. Then run the tests.
@@ -141,7 +140,7 @@ To run the tests against ckan 2.9.x on Python3:
    configuration, so you should only need to rebuild the ckan image if you change the extension's
    dependencies.
    ```shell
-   docker-compose run ckan
+   docker compose run ckan
    ```
 
 <!--testing-end-->


### PR DESCRIPTION
docker-compose is deprecated and tests were no longer running.